### PR TITLE
Fix loading screen check

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -47,7 +47,7 @@
   // @brief '/' にアクセスしたときにローディング画面を表示する
   // @detail 3秒後にローディング画面を非表示にする
   onMounted(() => {
-    if (isHome) {
+    if (isHome.value) {
       setTimeout(() => {
         showLoading.value = false
       }, 3000)


### PR DESCRIPTION
## Summary
- ensure `isHome` computed is dereferenced when checking current route

## Testing
- `npm run lint` *(fails: jiti library missing)*
- `npm run type-check` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406d869bb88333acf4afaccb1f1e0d